### PR TITLE
add context-aware method to enable timeout + cancel for connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,20 @@ import (
 )
 
 func main() {
+    // Option. Context for set timeout. Default timeout value is 5 seconds.
+	timeout := 800
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Millisecond)
+    defer cancel()
+    
     msg := email.Message{
         To: "you@server.name", // do not add < > or name in quotes
         From: "me@server.name", // do not add < > or name in quotes
         Subject: "A simple email",
         Body: "Plain text email body. HTML not yet supported, but send a PR!",
-
-        WaitTime: 100 // Set timeout as 100 Milliseconds
     }
+
+    // Option. Context for set timeout. Default timeout value is 5 seconds.
+	email.SendContext(ctx)
 
     err := msg.Send()
     if err != nil {

--- a/README.md
+++ b/README.md
@@ -12,16 +12,13 @@ keys from a third-party just to send something like an account recovery email.
 package main
 
 import (
+    "context"
     "fmt"
+    
     "github.com/nilslice/email"
 )
 
-func main() {
-    // Option. Context for set timeout. Default timeout value is 5 seconds.
-	timeout := 800
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Millisecond)
-    defer cancel()
-    
+func main() {    
     msg := email.Message{
         To: "you@server.name", // do not add < > or name in quotes
         From: "me@server.name", // do not add < > or name in quotes
@@ -29,10 +26,14 @@ func main() {
         Body: "Plain text email body. HTML not yet supported, but send a PR!",
     }
 
-    // Option. Context for set timeout. Default timeout value is 5 seconds.
-	email.SendContext(ctx)
-
     err := msg.Send()
+    if err != nil {
+        fmt.Println(err)
+    }
+
+    // or with context-aware API
+    ctx := context.WithTimeout(context.Background(), time.Second * 3)
+    err = msg.SendWithContext(ctx)
     if err != nil {
         fmt.Println(err)
     }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ func main() {
         From: "me@server.name", // do not add < > or name in quotes
         Subject: "A simple email",
         Body: "Plain text email body. HTML not yet supported, but send a PR!",
+
+        WaitTime: 100 // Set timeout as 100 Milliseconds
     }
 
     err := msg.Send()


### PR DESCRIPTION
@practice-golang, I couldn't push to your branch, so I've pulled your changes into a branch here. Some minor modifications have been made, but I'd like you to verify (if possible) that the sending still works as expected. 

Each context should be passed in per call to `SendWithContext` so that a new context is used per dial, rather than using a global context at the package level. This isn't a super obvious pattern, and I'm sure your solution would have been ok in most cases! This is just a safer way to guarantee that no goroutines share the same context and end up colliding cancellations or timeouts. 

If you can, please test in the sending environment you have been working in and let me know if there are any issues. Thanks for your help!